### PR TITLE
Clean up generic engine configs

### DIFF
--- a/GameData/Starcatcher's Mods/TestFlight-Stock/Generic/Generic.cfg
+++ b/GameData/Starcatcher's Mods/TestFlight-Stock/Generic/Generic.cfg
@@ -319,7 +319,7 @@
         {
                 name = TestFlightReliability_DynamicPressure
                 configuration = #$../TESTFLIGHT,0/alias$
-                temperatureCurve
+                reliabilityAtPressure
                 {
                         // Normalize to flight at 5 km
                         maxPressure = 75530.658

--- a/GameData/Starcatcher's Mods/TestFlight-Stock/Generic/Generic.cfg
+++ b/GameData/Starcatcher's Mods/TestFlight-Stock/Generic/Generic.cfg
@@ -198,7 +198,6 @@
         {
                 name = FlightDataRecorder_Engine
                 configuration = #$../TESTFLIGHT,0/alias$
-                engineID = #$../TESTFLIGHT,0/engines$
                 flightDataMultiplier = #$../TESTFLIGHT,0/dataMult$
         }
 

--- a/GameData/Starcatcher's Mods/TestFlight-Stock/Generic/Generic.cfg
+++ b/GameData/Starcatcher's Mods/TestFlight-Stock/Generic/Generic.cfg
@@ -481,8 +481,8 @@
         MODULE
         {
                 name = TestFlightFailure_ShutdownEngine
-                engineID = #$../TFENGINE,0/engines$
-                configuration = #$../TFENGINE,0/alias$
+                engineID = #$../TESTFLIGHT,0/engines$
+                configuration = #$../TESTFLIGHT,0/alias$
                 duFail = 100
                 duRepair = 50
                 failureTitle = Engine Shutdown
@@ -493,8 +493,8 @@
         MODULE
         {
                 name = TestFlightFailure_EnginePerformanceLoss
-                engineID = #$../TFENGINE,0/engines$
-                configuration = #$../TFENGINE,0/alias$
+                engineID = #$../TESTFLIGHT,0/engines$
+                configuration = #$../TESTFLIGHT,0/alias$
                 duFail = 100
                 duRepair = 250
                 failureTitle = Performance Loss
@@ -507,8 +507,8 @@
         MODULE
         {
                 name = TestFlightFailure_ReducedMaxThrust
-                engineID = #$../TFENGINE,0/engines$
-                configuration = #$../TFENGINE,0/alias$
+                engineID = #$../TESTFLIGHT,0/engines$
+                configuration = #$../TESTFLIGHT,0/alias$
                 duFail = 100
                 duRepair = 250
                 failureTitle = Reduced Fuel Flow

--- a/GameData/Starcatcher's Mods/TestFlight-Stock/Generic/Generic.cfg
+++ b/GameData/Starcatcher's Mods/TestFlight-Stock/Generic/Generic.cfg
@@ -518,7 +518,7 @@
         }
 }
 
-@PART[*]:HAS[@TESTFLIGHT]:HAS[#electrothermalFailures[?rue]]]:FOR[zTestFlight]
+@PART[*]:HAS[@TESTFLIGHT:HAS[#electrothermalFailures[?rue]]]:FOR[zTestFlight]
 {
         MODULE
         {

--- a/GameData/Starcatcher's Mods/TestFlight-Stock/Generic/Generic.cfg
+++ b/GameData/Starcatcher's Mods/TestFlight-Stock/Generic/Generic.cfg
@@ -269,7 +269,7 @@
                 configuration = #$../TESTFLIGHT,0/alias$
                 engineID = #$../TESTFLIGHT,0/engines$
                 ratedBurnTime = #$../TESTFLIGHT,0/ratedBurnTime$
-                idleDecayRate = 0.1
+
                 cycle
                 {
                         key = 0.00 10.00
@@ -917,17 +917,6 @@
         @MODULE[TestFlightFailure*]:HAS[#engineID[]]
         {
                 @engineID = all
-        }
-}
-
-//------------------------------------------------------------------
-// No decay for single-use engines. Doesn't really matter, but makes for less confusing UI
-
-@PART[*]:HAS[@MODULE[TestFlightReliability_EngineCycle],@MODULE[ModuleEngines*]:HAS[#allowShutdown[?alse]]]:AFTER[zTestFlight]
-{
-        @MODULE[TestFlightReliability_EngineCycle]
-        {
-                !idleDecayRate = DEL
         }
 }
 


### PR DESCRIPTION
This PR removes some references in the generic config that don't correspond to real fields in the TestFlight 2 PartModules. I haven't investigated whether any of the remaining fields have changed meaning between TestFlight 1 and 2, and I did only a basic check to make sure a demo flight behaved the same with both configs.

I haven't done anything about the transition from `cycle` to `continuousCycle` and `ratedBurnTime` to `ratedContinuousBurnTime`, as @Starcatcher2009 mentioned he already had a better fix for that.