### PR TITLE
Add engine configs for Cryo Engines

### DIFF
--- a/GameData/Starcatcher's Mods/TestFlight-Stock/CE_Engines.cfg
+++ b/GameData/Starcatcher's Mods/TestFlight-Stock/CE_Engines.cfg
@@ -1,0 +1,408 @@
+// TestFlight configs for all engines in Cryo Engines
+// See Generic_Engines.cfg for documentation on TESTFLIGHT
+
+//------------------------------------------------
+// Hydrolox engines
+
+// 0.625 m
+
+@PART[cryoengine-stromboli-1]:HAS[!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+       name = CR-10A
+       ratedBurnTime = 180
+       cycleReliabilityStart = 0.45
+       cycleReliabilityEnd = 0.99
+
+       liquidFuelFailures = True
+       ignitionFailures = True
+       ignitionReliabilityStart = 0.75
+       ignitionReliabilityEnd = 0.999
+    }
+}
+
+// 1.25 m
+
+@PART[cryoengine-vesuvius-1]:HAS[!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+       name = CR-2
+       ratedBurnTime = 120
+       cycleReliabilityStart = 0.40
+       cycleReliabilityEnd = 0.99
+
+       liquidFuelFailures = True
+       ignitionFailures = True
+       ignitionReliabilityStart = 0.75
+       ignitionReliabilityEnd = 0.999
+    }
+}
+
+@PART[cryoengine-hecate-1]:HAS[!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+       name = CE-10
+       ratedBurnTime = 380
+       cycleReliabilityStart = 0.35     // Reduced reliability from nozzle
+       cycleReliabilityEnd = 0.98       // Reduced reliability from nozzle
+
+       liquidFuelFailures = True
+       ignitionFailures = True
+       ignitionReliabilityStart = 0.80
+       ignitionReliabilityEnd = 0.999
+
+       techTransfer = CR-10A:25
+    }
+}
+
+// 1.875 m
+
+@PART[cryoengine-erebus-1]:HAS[!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+       name = CR-0120
+       ratedBurnTime = 105
+       cycleReliabilityStart = 0.40
+       cycleReliabilityEnd = 0.99
+
+       liquidFuelFailures = True
+       ignitionFailures = True
+       ignitionReliabilityStart = 0.75
+       ignitionReliabilityEnd = 0.999
+    }
+}
+
+@PART[cryoengine-pavonis-1]:HAS[!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+       name = CE-60
+       ratedBurnTime = 280
+       cycleReliabilityStart = 0.40     // Reduced reliability from nozzle
+       cycleReliabilityEnd = 0.98       // Reduced reliability from nozzle
+
+       liquidFuelFailures = True
+       ignitionFailures = True
+       ignitionReliabilityStart = 0.80
+       ignitionReliabilityEnd = 0.999
+
+       techTransfer = CR-10A:25
+    }
+}
+
+// 2.5 m
+
+@PART[cryoengine-fuji-1]:HAS[!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+       name = CR-9B
+       ratedBurnTime = 115
+       cycleReliabilityStart = 0.45
+       cycleReliabilityEnd = 0.99
+
+       liquidFuelFailures = True
+       ignitionFailures = True
+       ignitionReliabilityStart = 0.80
+       ignitionReliabilityEnd = 0.995
+
+       // Allow player to bypass 1.875m engines while still rewarding their use.
+       techTransfer = CR-2:35&CR-0120:35
+    }
+}
+
+@PART[cryoengine-ulysses-1]:HAS[!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+       name = CE-2X
+       ratedBurnTime = 220
+       cycleReliabilityStart = 0.45
+       cycleReliabilityEnd = 0.99
+
+       liquidFuelFailures = True
+       ignitionFailures = True
+       ignitionReliabilityStart = 0.85
+       ignitionReliabilityEnd = 0.999
+
+       // Allow player to bypass 1.875m engines while still rewarding their use.
+       techTransfer = CE-10:35&CE-60:35
+    }
+}
+
+// 3.75 m
+
+@PART[cryoengine-etna-1]:HAS[!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+       name = CR-68
+       ratedBurnTime = 90
+       cycleReliabilityStart = 0.45
+       cycleReliabilityEnd = 0.99
+
+       liquidFuelFailures = True
+       ignitionFailures = True
+       ignitionReliabilityStart = 0.85
+       ignitionReliabilityEnd = 0.995
+
+       techTransfer = CR-9B:50
+    }
+}
+
+// Complex double-gimbal system more failure-prone
+@PART[cryoengine-etna-1]:HAS[@MODULE[TestFlightFailure_LockGimbal]]:AFTER[zTestFlight]
+{
+    @MODULE[TestFlightFailure_*Gimbal*]
+    {
+        @weight *= 2
+    }
+}
+
+@PART[cryoengine-tharsis-1]:HAS[!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+       name = CE-60x2
+       ratedBurnTime = 310
+       cycleReliabilityStart = 0.45
+       cycleReliabilityEnd = 0.98       // Reduced reliability from nozzle
+
+       clusterMultiplier = 2
+
+       liquidFuelFailures = True
+       ignitionFailures = True
+       ignitionReliabilityStart = 0.85
+       ignitionReliabilityEnd = 0.995
+
+       techTransfer = CE-60:75
+    }
+}
+
+// Multi-piece nozzle seems like a leak waiting to happen
+@PART[cryoengine-hecate-1|cryoengine-pavonis-1|cryoengine-tharsis-1]:AFTER[zTestFlight]
+{
+    @MODULE[TestFlightFailure_EnginePerformanceLoss]
+    {
+        @weight *= 2
+    }
+    @MODULE[TestFlightFailure_Explode]
+    {
+        @weight *= 2
+    }
+}
+
+//------------------------------------------------
+// Methalox engines
+
+// 0.625 m
+
+@PART[cryoengine-compsognathus-1]:HAS[!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+       name = MR-1
+       ratedBurnTime = 80
+       cycleReliabilityStart = 0.40
+       cycleReliabilityEnd = 0.99
+
+       liquidFuelFailures = True
+       ignitionFailures = True
+       ignitionReliabilityStart = 0.75
+       ignitionReliabilityEnd = 0.999
+    }
+}
+
+@PART[cryoengine-hawk-1]:HAS[!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+       name = MU-018
+       ratedBurnTime = 350
+       cycleReliabilityStart = 0.45
+       cycleReliabilityEnd = 0.99
+
+       liquidFuelFailures = True
+       ignitionFailures = True
+       ignitionReliabilityStart = 0.80
+       ignitionReliabilityEnd = 0.999
+    }
+
+    techTransfer = MR-1:25
+}
+
+// 1.25 m
+
+@PART[cryoengine-deinonychus-1]:HAS[!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+       name = MR-420
+       ratedBurnTime = 75
+       cycleReliabilityStart = 0.45
+       cycleReliabilityEnd = 0.99
+
+       liquidFuelFailures = True
+       ignitionFailures = True
+       ignitionReliabilityStart = 0.80
+       ignitionReliabilityEnd = 0.999
+    }
+
+    techTransfer = MR-1:50
+}
+
+@PART[cryoengine-buzzard-1]:HAS[!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+       name = MU-10
+       ratedBurnTime = 380
+       cycleReliabilityStart = 0.45
+       cycleReliabilityEnd = 0.99
+
+       liquidFuelFailures = True
+       ignitionFailures = True
+       ignitionReliabilityStart = 0.80
+       ignitionReliabilityEnd = 0.999
+
+       techTransfer = MR-1:25
+    }
+}
+
+// 1.875 m
+
+@PART[cryoengine-iguanodon-1]:HAS[!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+       name = MR-4
+       ratedBurnTime = 100
+       cycleReliabilityStart = 0.45
+       cycleReliabilityEnd = 0.99
+
+       liquidFuelFailures = True
+       ignitionFailures = True
+       ignitionReliabilityStart = 0.85
+       ignitionReliabilityEnd = 0.999
+    }
+
+    techTransfer = MR-420,MR-1:50
+}
+
+@PART[cryoengine-harrier-1]:HAS[!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+       name = MU-11
+       ratedBurnTime = 360
+       cycleReliabilityStart = 0.45
+       cycleReliabilityEnd = 0.99
+
+       liquidFuelFailures = True
+       ignitionFailures = True
+       ignitionReliabilityStart = 0.85
+       ignitionReliabilityEnd = 0.999
+
+       techTransfer = MU-10:50
+    }
+}
+
+// 2.5 m
+
+@PART[cryoengine-allosaur-1]:HAS[!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+       name = MR-8
+       ratedBurnTime = 100
+       cycleReliabilityStart = 0.45
+       cycleReliabilityEnd = 0.99
+
+       liquidFuelFailures = True
+       ignitionFailures = True
+       ignitionReliabilityStart = 0.85
+       ignitionReliabilityEnd = 0.995
+
+       // Allow player to bypass 1.875m engines while still rewarding their use.
+       techTransfer = MR-420,MR-1:35&MR-4:35
+    }
+}
+
+@PART[cryoengine-eagle-1]:HAS[!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+       name = MU-421
+       ratedBurnTime = 350
+       cycleReliabilityStart = 0.45
+       cycleReliabilityEnd = 0.99
+
+       liquidFuelFailures = True
+       ignitionFailures = True
+       ignitionReliabilityStart = 0.85
+       ignitionReliabilityEnd = 0.999
+
+       // Allow player to bypass 1.875m engines while still rewarding their use.
+       // Number and description imply it's derived from the MR-420 Deinonychus.
+       techTransfer = MU-10:25&MU-11:25&MR-420:15
+    }
+}
+
+// 3.75 m
+
+@PART[cryoengine-tyrannosaur-1]:HAS[!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+       name = MR-420-9
+       ratedBurnTime = 75
+       cycleReliabilityStart = 0.45
+       cycleReliabilityEnd = 0.99
+
+       clusterMultiplier = 9
+
+       liquidFuelFailures = True
+       ignitionFailures = True
+       ignitionReliabilityStart = 0.85
+       ignitionReliabilityEnd = 0.995
+
+       // Cluster of MR-420 engines.
+       techTransfer = MR-420:75
+    }
+}
+
+@PART[cryoengine-vulture-1]:HAS[!MODULE[TestFlightInterop]]:BEFORE[zTestFlight]
+{
+    TESTFLIGHT
+    {
+       name = MU-4U
+       ratedBurnTime = 215
+       cycleReliabilityStart = 0.35     // Reduced reliability from nozzle
+       cycleReliabilityEnd = 0.98       // Reduced reliability from nozzle
+
+       liquidFuelFailures = True
+       ignitionFailures = True
+       ignitionReliabilityStart = 0.85
+       ignitionReliabilityEnd = 0.995
+
+       // Description implies it's derived from the MR-4 Iguanodon.
+       techTransfer = MU-421:50&MR-4:25
+    }
+}
+
+// Multi-piece nozzle seems like a leak waiting to happen
+@PART[cryoengine-vulture-1]:AFTER[zTestFlight]
+{
+    @MODULE[TestFlightFailure_EnginePerformanceLoss]
+    {
+        @weight *= 2
+    }
+    @MODULE[TestFlightFailure_Explode]
+    {
+        @weight *= 2
+    }
+}

--- a/GameData/Starcatcher's Mods/TestFlight-Stock/CE_Engines.cfg
+++ b/GameData/Starcatcher's Mods/TestFlight-Stock/CE_Engines.cfg
@@ -11,14 +11,21 @@
     TESTFLIGHT
     {
        name = CR-10A
+
+       thrustModifier
+       {
+           key = 0.00 0.05 0 0
+           key = 1.00 1.00 3 3
+       }
+
        ratedBurnTime = 180
        cycleReliabilityStart = 0.45
-       cycleReliabilityEnd = 0.99
+       cycleReliabilityEnd = 0.95
 
        liquidFuelFailures = True
        ignitionFailures = True
        ignitionReliabilityStart = 0.75
-       ignitionReliabilityEnd = 0.999
+       ignitionReliabilityEnd = 0.97
     }
 }
 
@@ -29,14 +36,21 @@
     TESTFLIGHT
     {
        name = CR-2
+
+       thrustModifier
+       {
+           key = 0.00 0.05 0 0
+           key = 1.00 1.00 3 3
+       }
+
        ratedBurnTime = 120
        cycleReliabilityStart = 0.40
-       cycleReliabilityEnd = 0.99
+       cycleReliabilityEnd = 0.95
 
        liquidFuelFailures = True
        ignitionFailures = True
        ignitionReliabilityStart = 0.75
-       ignitionReliabilityEnd = 0.999
+       ignitionReliabilityEnd = 0.97
     }
 }
 
@@ -45,14 +59,21 @@
     TESTFLIGHT
     {
        name = CE-10
+
+       thrustModifier
+       {
+           key = 0.00 0.05 0 0
+           key = 1.00 1.00 3 3
+       }
+
        ratedBurnTime = 380
        cycleReliabilityStart = 0.35     // Reduced reliability from nozzle
-       cycleReliabilityEnd = 0.98       // Reduced reliability from nozzle
+       cycleReliabilityEnd = 0.92       // Reduced reliability from nozzle
 
        liquidFuelFailures = True
        ignitionFailures = True
        ignitionReliabilityStart = 0.80
-       ignitionReliabilityEnd = 0.999
+       ignitionReliabilityEnd = 0.97
 
        techTransfer = CR-10A:25
     }
@@ -65,14 +86,21 @@
     TESTFLIGHT
     {
        name = CR-0120
+
+       thrustModifier
+       {
+           key = 0.00 0.05 0 0
+           key = 1.00 1.00 3 3
+       }
+
        ratedBurnTime = 105
        cycleReliabilityStart = 0.40
-       cycleReliabilityEnd = 0.99
+       cycleReliabilityEnd = 0.95
 
        liquidFuelFailures = True
        ignitionFailures = True
        ignitionReliabilityStart = 0.75
-       ignitionReliabilityEnd = 0.999
+       ignitionReliabilityEnd = 0.97
     }
 }
 
@@ -81,14 +109,21 @@
     TESTFLIGHT
     {
        name = CE-60
+
+       thrustModifier
+       {
+           key = 0.00 0.05 0 0
+           key = 1.00 1.00 3 3
+       }
+
        ratedBurnTime = 280
        cycleReliabilityStart = 0.40     // Reduced reliability from nozzle
-       cycleReliabilityEnd = 0.98       // Reduced reliability from nozzle
+       cycleReliabilityEnd = 0.92       // Reduced reliability from nozzle
 
        liquidFuelFailures = True
        ignitionFailures = True
        ignitionReliabilityStart = 0.80
-       ignitionReliabilityEnd = 0.999
+       ignitionReliabilityEnd = 0.97
 
        techTransfer = CR-10A:25
     }
@@ -101,14 +136,21 @@
     TESTFLIGHT
     {
        name = CR-9B
+
+       thrustModifier
+       {
+           key = 0.00 0.05 0 0
+           key = 1.00 1.00 3 3
+       }
+
        ratedBurnTime = 115
        cycleReliabilityStart = 0.45
-       cycleReliabilityEnd = 0.99
+       cycleReliabilityEnd = 0.95
 
        liquidFuelFailures = True
        ignitionFailures = True
        ignitionReliabilityStart = 0.80
-       ignitionReliabilityEnd = 0.995
+       ignitionReliabilityEnd = 0.95
 
        // Allow player to bypass 1.875m engines while still rewarding their use.
        techTransfer = CR-2:35&CR-0120:35
@@ -120,14 +162,21 @@
     TESTFLIGHT
     {
        name = CE-2X
+
+       thrustModifier
+       {
+           key = 0.00 0.05 0 0
+           key = 1.00 1.00 3 3
+       }
+
        ratedBurnTime = 220
        cycleReliabilityStart = 0.45
-       cycleReliabilityEnd = 0.99
+       cycleReliabilityEnd = 0.95
 
        liquidFuelFailures = True
        ignitionFailures = True
        ignitionReliabilityStart = 0.85
-       ignitionReliabilityEnd = 0.999
+       ignitionReliabilityEnd = 0.97
 
        // Allow player to bypass 1.875m engines while still rewarding their use.
        techTransfer = CE-10:35&CE-60:35
@@ -141,14 +190,21 @@
     TESTFLIGHT
     {
        name = CR-68
+
+       thrustModifier
+       {
+           key = 0.00 0.05 0 0
+           key = 1.00 1.00 3 3
+       }
+
        ratedBurnTime = 90
        cycleReliabilityStart = 0.45
-       cycleReliabilityEnd = 0.99
+       cycleReliabilityEnd = 0.95
 
        liquidFuelFailures = True
        ignitionFailures = True
        ignitionReliabilityStart = 0.85
-       ignitionReliabilityEnd = 0.995
+       ignitionReliabilityEnd = 0.95
 
        techTransfer = CR-9B:50
     }
@@ -168,16 +224,23 @@
     TESTFLIGHT
     {
        name = CE-60x2
+
+       thrustModifier
+       {
+           key = 0.00 0.05 0 0
+           key = 1.00 1.00 3 3
+       }
+
        ratedBurnTime = 310
        cycleReliabilityStart = 0.45
-       cycleReliabilityEnd = 0.98       // Reduced reliability from nozzle
+       cycleReliabilityEnd = 0.92       // Reduced reliability from nozzle
 
        clusterMultiplier = 2
 
        liquidFuelFailures = True
        ignitionFailures = True
        ignitionReliabilityStart = 0.85
-       ignitionReliabilityEnd = 0.995
+       ignitionReliabilityEnd = 0.95
 
        techTransfer = CE-60:75
     }
@@ -206,14 +269,21 @@
     TESTFLIGHT
     {
        name = MR-1
+
+       thrustModifier
+       {
+           key = 0.00 0.05 0 0
+           key = 1.00 1.00 3 3
+       }
+
        ratedBurnTime = 80
        cycleReliabilityStart = 0.40
-       cycleReliabilityEnd = 0.99
+       cycleReliabilityEnd = 0.95
 
        liquidFuelFailures = True
        ignitionFailures = True
        ignitionReliabilityStart = 0.75
-       ignitionReliabilityEnd = 0.999
+       ignitionReliabilityEnd = 0.97
     }
 }
 
@@ -222,14 +292,21 @@
     TESTFLIGHT
     {
        name = MU-018
+
+       thrustModifier
+       {
+           key = 0.00 0.05 0 0
+           key = 1.00 1.00 3 3
+       }
+
        ratedBurnTime = 350
        cycleReliabilityStart = 0.45
-       cycleReliabilityEnd = 0.99
+       cycleReliabilityEnd = 0.95
 
        liquidFuelFailures = True
        ignitionFailures = True
        ignitionReliabilityStart = 0.80
-       ignitionReliabilityEnd = 0.999
+       ignitionReliabilityEnd = 0.97
     }
 
     techTransfer = MR-1:25
@@ -242,14 +319,21 @@
     TESTFLIGHT
     {
        name = MR-420
+
+       thrustModifier
+       {
+           key = 0.00 0.05 0 0
+           key = 1.00 1.00 3 3
+       }
+
        ratedBurnTime = 75
        cycleReliabilityStart = 0.45
-       cycleReliabilityEnd = 0.99
+       cycleReliabilityEnd = 0.95
 
        liquidFuelFailures = True
        ignitionFailures = True
        ignitionReliabilityStart = 0.80
-       ignitionReliabilityEnd = 0.999
+       ignitionReliabilityEnd = 0.97
     }
 
     techTransfer = MR-1:50
@@ -260,14 +344,21 @@
     TESTFLIGHT
     {
        name = MU-10
+
+       thrustModifier
+       {
+           key = 0.00 0.05 0 0
+           key = 1.00 1.00 3 3
+       }
+
        ratedBurnTime = 380
        cycleReliabilityStart = 0.45
-       cycleReliabilityEnd = 0.99
+       cycleReliabilityEnd = 0.95
 
        liquidFuelFailures = True
        ignitionFailures = True
        ignitionReliabilityStart = 0.80
-       ignitionReliabilityEnd = 0.999
+       ignitionReliabilityEnd = 0.97
 
        techTransfer = MR-1:25
     }
@@ -280,14 +371,21 @@
     TESTFLIGHT
     {
        name = MR-4
+
+       thrustModifier
+       {
+           key = 0.00 0.05 0 0
+           key = 1.00 1.00 3 3
+       }
+
        ratedBurnTime = 100
        cycleReliabilityStart = 0.45
-       cycleReliabilityEnd = 0.99
+       cycleReliabilityEnd = 0.95
 
        liquidFuelFailures = True
        ignitionFailures = True
        ignitionReliabilityStart = 0.85
-       ignitionReliabilityEnd = 0.999
+       ignitionReliabilityEnd = 0.97
     }
 
     techTransfer = MR-420,MR-1:50
@@ -298,14 +396,21 @@
     TESTFLIGHT
     {
        name = MU-11
+
+       thrustModifier
+       {
+           key = 0.00 0.05 0 0
+           key = 1.00 1.00 3 3
+       }
+
        ratedBurnTime = 360
        cycleReliabilityStart = 0.45
-       cycleReliabilityEnd = 0.99
+       cycleReliabilityEnd = 0.95
 
        liquidFuelFailures = True
        ignitionFailures = True
        ignitionReliabilityStart = 0.85
-       ignitionReliabilityEnd = 0.999
+       ignitionReliabilityEnd = 0.97
 
        techTransfer = MU-10:50
     }
@@ -318,14 +423,21 @@
     TESTFLIGHT
     {
        name = MR-8
+
+       thrustModifier
+       {
+           key = 0.00 0.05 0 0
+           key = 1.00 1.00 3 3
+       }
+
        ratedBurnTime = 100
        cycleReliabilityStart = 0.45
-       cycleReliabilityEnd = 0.99
+       cycleReliabilityEnd = 0.95
 
        liquidFuelFailures = True
        ignitionFailures = True
        ignitionReliabilityStart = 0.85
-       ignitionReliabilityEnd = 0.995
+       ignitionReliabilityEnd = 0.95
 
        // Allow player to bypass 1.875m engines while still rewarding their use.
        techTransfer = MR-420,MR-1:35&MR-4:35
@@ -337,14 +449,21 @@
     TESTFLIGHT
     {
        name = MU-421
+
+       thrustModifier
+       {
+           key = 0.00 0.05 0 0
+           key = 1.00 1.00 3 3
+       }
+
        ratedBurnTime = 350
        cycleReliabilityStart = 0.45
-       cycleReliabilityEnd = 0.99
+       cycleReliabilityEnd = 0.95
 
        liquidFuelFailures = True
        ignitionFailures = True
        ignitionReliabilityStart = 0.85
-       ignitionReliabilityEnd = 0.999
+       ignitionReliabilityEnd = 0.95
 
        // Allow player to bypass 1.875m engines while still rewarding their use.
        // Number and description imply it's derived from the MR-420 Deinonychus.
@@ -359,16 +478,23 @@
     TESTFLIGHT
     {
        name = MR-420-9
+
+       thrustModifier
+       {
+           key = 0.00 0.05 0 0
+           key = 1.00 1.00 3 3
+       }
+
        ratedBurnTime = 75
        cycleReliabilityStart = 0.45
-       cycleReliabilityEnd = 0.99
+       cycleReliabilityEnd = 0.95
 
        clusterMultiplier = 9
 
        liquidFuelFailures = True
        ignitionFailures = True
        ignitionReliabilityStart = 0.85
-       ignitionReliabilityEnd = 0.995
+       ignitionReliabilityEnd = 0.95
 
        // Cluster of MR-420 engines.
        techTransfer = MR-420:75
@@ -380,14 +506,21 @@
     TESTFLIGHT
     {
        name = MU-4U
+
+       thrustModifier
+       {
+           key = 0.00 0.05 0 0
+           key = 1.00 1.00 3 3
+       }
+
        ratedBurnTime = 215
        cycleReliabilityStart = 0.35     // Reduced reliability from nozzle
-       cycleReliabilityEnd = 0.98       // Reduced reliability from nozzle
+       cycleReliabilityEnd = 0.92       // Reduced reliability from nozzle
 
        liquidFuelFailures = True
        ignitionFailures = True
        ignitionReliabilityStart = 0.85
-       ignitionReliabilityEnd = 0.995
+       ignitionReliabilityEnd = 0.95
 
        // Description implies it's derived from the MR-4 Iguanodon.
        techTransfer = MU-421:50&MR-4:25

--- a/GameData/Starcatcher's Mods/TestFlight-Stock/KA_Engines.cfg
+++ b/GameData/Starcatcher's Mods/TestFlight-Stock/KA_Engines.cfg
@@ -25,8 +25,8 @@
 
        ratedBurnTime = 1040
 
-       cycleReliabilityStart = 0.7
-       cycleReliabilityEnd = 0.98
+       cycleReliabilityStart = 0.6      // Reduced reliability from nozzle
+       cycleReliabilityEnd = 0.95       // Reduced reliability from nozzle
 
        ignitionReliabilityStart = 0.7
        ignitionReliabilityEnd = 0.98
@@ -126,7 +126,7 @@
        ratedBurnTime = 980
 
        cycleReliabilityStart = 0.8
-       cycleReliabilityEnd = 0.98
+       cycleReliabilityEnd = 0.95      // Reduced reliability from nozzle
 
        ignitionReliabilityStart = 0.8
        ignitionReliabilityEnd = 0.98
@@ -184,7 +184,7 @@
        ratedBurnTime = 600
 
        cycleReliabilityStart = 0.65
-       cycleReliabilityEnd = 0.95
+       cycleReliabilityEnd = 0.93      // Reduced reliability from nozzle
        reliabilityDataRateMultiplier = 2.0 // 19/83 minutes of flight testing
 
        ignitionReliabilityStart = 0.65
@@ -248,5 +248,18 @@
        ignitionReliabilityEnd = 0.95
 
        techTransfer = NV-GE,NV-DC:25
+    }
+}
+
+// Multi-piece nozzle seems like a leak waiting to happen
+@PART[ntr-sc-0625-1|ntr-gc-25-1|ntr-sc-25-1]:AFTER[zTestFlight]
+{
+    @MODULE[TestFlightFailure_EnginePerformanceLoss]
+    {
+        @weight *= 2
+    }
+    @MODULE[TestFlightFailure_Explode]
+    {
+        @weight *= 2
     }
 }


### PR DESCRIPTION
This is a hand-converted version of the Cryo Engines configs I've been playing with under TF1, in response to popular demand. These configs are likely to be poorly balanced, especially the rated burn time, as I don't yet have a good feel for what a balanced hydrolox or methalox rocket looks like. The current RBTs are simply thrust-based scalings from the closest equivalent stock engine.

Many of the Cryo Engines use the Deployable Engines plugin to create a two-piece nozzle; I've tweaked the Kerbal Atomics configs that use DE to match.